### PR TITLE
test: add MemPool and symm_mem.empty storage-reuse tests

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1945,6 +1945,55 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         expected = torch.mm(x, w) * self.world_size
         self.assertEqual(y, expected)
 
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_mempool_storage_reuse(self):
+        """MemPool with no_split=True returns the same VA for same-size allocs."""
+        self._init_process()
+
+        mempool = symm_mem.get_mem_pool(self.device)
+        numel = 1024
+        dtype = torch.float
+
+        with torch.cuda.use_mem_pool(mempool):
+            t1 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        with torch.cuda.use_mem_pool(mempool):
+            t2 = torch.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1, ptr2, "MemPool should return the same storage block for same-size re-allocation"
+        )
+
+    @skipIf(TEST_WITH_ROCM, "https://github.com/pytorch/pytorch/issues/180464")
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_symm_mem_empty_storage_reuse(self):
+        """symm_mem.empty() reuses storage across alloc/free cycles via the MemPool."""
+        self._init_process()
+
+        numel = 1024
+        dtype = torch.float
+
+        t1 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr1 = t1.data_ptr()
+        del t1
+
+        t2 = symm_mem.empty(numel, dtype=dtype, device=self.device)
+        ptr2 = t2.data_ptr()
+
+        self.assertEqual(
+            ptr1, ptr2, "symm_mem.empty() should reuse the same storage block via the implicit MemPool"
+        )
+
 
 @instantiate_parametrized_tests
 @requires_cuda_p2p_access()


### PR DESCRIPTION
Adds two tests to `SymmMemPoolTest` verifying that the implicit MemPool
(no_split=True) returns the same VA for same-size allocations after free:

- `test_mempool_storage_reuse`: allocates a tensor through the device
  MemPool, frees it, reallocates at the same size, and asserts the VA
  is identical — confirming that no_split=True causes the allocator to
  return the same block.

- `test_symm_mem_empty_storage_reuse`: exercises the same guarantee
  end-to-end through `symm_mem.empty()`, which routes allocations
  through the implicit per-device MemPool added in #187054.

Depends on #187054.